### PR TITLE
Issues/#52457b pagination context

### DIFF
--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
@@ -104,6 +104,8 @@ class ProductCollection extends AbstractBlock {
 		// Provide location context into block's context.
 		add_filter( 'render_block_context', array( $this, 'provide_location_context_for_inner_blocks' ), 11, 1 );
 
+		// Consume reload context from pagination block.
+		add_filter( 'block_type_metadata', array( $this, 'uses_context_for_pagination' ), 10, 3 );
 
 		// Disable block render if the ProductTemplate block is empty.
 		add_filter(
@@ -283,6 +285,19 @@ class ProductCollection extends AbstractBlock {
 			$location_context = ProductCollectionUtils::parse_frontend_location_context();
 		}
 		return $location_context;
+	}
+
+	/**
+	 * Consume 'forcePageReload' context from the core/pagination block.
+	 *
+	 * @param array $metadata Metadata for registering a block type.
+	 * @return array
+	 */
+	public function uses_context_for_pagination( $metadata ) {
+		if ( 'core/query-pagination' === $metadata['name'] ) {
+			$metadata['usesContext'][] = 'forcePageReload';
+		}
+		return $metadata;
 	}
 
 	/**

--- a/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypes/ProductCollection.php
@@ -104,8 +104,6 @@ class ProductCollection extends AbstractBlock {
 		// Provide location context into block's context.
 		add_filter( 'render_block_context', array( $this, 'provide_location_context_for_inner_blocks' ), 11, 1 );
 
-		// Provide location context into block's context.
-		add_filter( 'render_block_context', array( $this, 'provide_context_for_pagination' ), 20, 3 );
 
 		// Disable block render if the ProductTemplate block is empty.
 		add_filter(
@@ -267,32 +265,6 @@ class ProductCollection extends AbstractBlock {
 				'productId' => absint( $context['postId'] ),
 			),
 		) : $this->get_location_context();
-
-		return $context;
-	}
-
-	/**
-	 * Provides forcePageReload context for the pagination block.
-	 *
-	 * @param array $context  The block context.
-	 * @param array         $parsed_block An associative array of the block being rendered. See WP_Block_Parser_Block.
-	 * @param WP_Block|null $parent_block If this is a nested block, a reference to the parent block.
-	 * @return array $context The block context including the forcePageReload context.
-	 */
-	public function provide_context_for_pagination( $context, $parsed_block, $parent_block ) {
-
-		// Run only on frontend.
-		// This is needed to avoid SSR renders while in editor. @see https://github.com/woocommerce/woocommerce/issues/45181.
-		if ( is_admin() || \WC()->is_rest_api_request() ) {
-			return $context;
-		}
-
-		// Target only product collection's inner block navigation blocks that use the 'query' context.
-		if ('core/query-pagination' !== $parsed_block['blockName'] || ! isset( $context['query'] ) || ! isset( $context['query']['isProductCollectionBlock'] ) || ! $context['query']['isProductCollectionBlock'] ) {
-			return $context;
-		}
-
-		$context['forcePageReload'] = $parent_block->parsed_block['attrs']['forcePageReload'] ?? false;
 
 		return $context;
 	}

--- a/plugins/woocommerce/src/Blocks/BlockTypesController.php
+++ b/plugins/woocommerce/src/Blocks/BlockTypesController.php
@@ -54,7 +54,7 @@ final class BlockTypesController {
 	 * Initialize class features.
 	 */
 	protected function init() { // phpcs:ignore WooCommerce.Functions.InternalInjectionMethod.MissingPublic
-		add_action( 'init', array( $this, 'register_blocks' ) );
+		add_action( 'init', array( $this, 'register_blocks' ), 5 );
 		add_action( 'wp_loaded', array( $this, 'register_block_patterns' ) );
 		add_filter( 'block_categories_all', array( $this, 'register_block_categories' ), 10, 2 );
 		add_filter( 'render_block', array( $this, 'add_data_attributes' ), 10, 2 );


### PR DESCRIPTION
This is a continuation of https://github.com/woocommerce/woocommerce/pull/52498

It adds `forcePageReload` to the `usesContext` definition of the `core/query-pagination` block. I found that this was doable by filtering the `block_type_metadata`.

However, attaching this filter from the `ProductCollection` class was too _late_ for targeting the `core/query-pagination` block as it had already been [registered on `init` with a default priority](https://github.com/WordPress/gutenberg/blob/d4d6d4c5898a9fe4f678bfb349d023aad211fc9c/packages/block-library/src/query-pagination/index.php#L43-L51). 

PR resolves that by registering Woo blocks with an earlier priority eebe539b3bf06964ad4d30dd4da786f6f695447b 

This should resolve the issues faced in the first half of this PR where the pagination directives aren't receiving the `forcePageReload` context... especially when deeply nested.